### PR TITLE
Update 3-exceptionHandling.py

### DIFF
--- a/chapter1/3-exceptionHandling.py
+++ b/chapter1/3-exceptionHandling.py
@@ -11,7 +11,7 @@ def getTitle(url):
         print(e)
         return None
     try:
-        bsObj = BeautifulSoup(html.read())
+        bsObj = BeautifulSoup(html.read(),"html.parser") //for python 3.5.1
         title = bsObj.body.h1
     except AttributeError as e:
         return None


### PR DESCRIPTION
in python 3.5.1 it will prompt :

Warning (from warnings module):
  File "D:\Python35\lib\site-packages\bs4__init__.py", line 166
    markup_type=markup_type))
UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "html.parser")
